### PR TITLE
VDP-2: added java generator

### DIFF
--- a/docs/generate-pex-api.md
+++ b/docs/generate-pex-api.md
@@ -1,3 +1,4 @@
+## Generate type-script Api
 ### Step 1 : Generate API stubs
 
 The following command will generate the API stubs in `<workspace>/pex-openapi/target/sdks/api/typescript`.
@@ -9,4 +10,14 @@ The api stubs can be found at:
 
 ```
 cd target/sdks/typescript
+```
+
+## Generate java Api
+
+### Step 1 : Generate API stubs
+
+The following command will generate the API stubs in `<workspace>/pex-openapi/target/classes/com/sphereon/pex/api`.
+
+```
+mvn clean install -P java
 ```

--- a/docs/generate-pex-models.md
+++ b/docs/generate-pex-models.md
@@ -1,3 +1,5 @@
+## Generate type-script models
+
 ### Step 1 : Generate models
 
 The following command will generate the models in `<workspace>/pex-openapi/target/sdks/models/typescript`.
@@ -93,3 +95,10 @@ You should expect this to be printed on the console.
 { alg: [ 'someAlgorithm' ] }
 ```
 
+## Generate java models
+
+### Step 1 : Generate models
+The following command will generate the models in `<workspace>/pex-openapi/target/classes/com/sphereon/pex/models`.
+```
+mvn clean install -P java
+```

--- a/docs/release-pex-models.md
+++ b/docs/release-pex-models.md
@@ -1,4 +1,4 @@
-## Releasing
+## Releasing type-script
 
 #### Step A : Update values
 
@@ -49,3 +49,13 @@ yarn publish --access public
 Check on `npmjs.com`
 
 Install the module following the included `README.md`. 
+
+
+## Releasing java
+
+If you have the correct settings in your local workspace, you can easily publish a new version on Sphereon repository (`sphereon-opensource-snapshots`)
+if you do, you can create and upload a new version with running:
+
+```
+mvn clean deploy -P java
+```

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <swagger-codegen-verbose>false</swagger-codegen-verbose>
     <swagger-parser.version>2.0.26</swagger-parser.version>
     <pex-models-version>1.1.0</pex-models-version>
+    <open-api-address>swagger/pex-openapi-1.1.0.yaml</open-api-address>
   </properties>
 
   <distributionManagement>
@@ -163,7 +164,7 @@
                 </goals>
                 <phase>generate-sources</phase>
                 <configuration>
-                  <inputSpec>swagger/pex-openapi-1.1.0.yaml</inputSpec>
+                  <inputSpec>${open-api-address}</inputSpec>
 
                   <generatorName>typescript-angular</generatorName>
 
@@ -187,6 +188,40 @@
 
                   <generateSupportingFiles>true</generateSupportingFiles>
                   <supportingFilesToGenerate>tsconfig.json,models.ts</supportingFilesToGenerate>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>models-java</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.openapitools</groupId>
+            <artifactId>openapi-generator-maven-plugin</artifactId>
+            <version>5.4.0</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <configuration>
+                  <inputSpec>${open-api-address}</inputSpec>
+                  <generatorName>java</generatorName>
+                  <apiPackage>com.sphereon.pex.api</apiPackage>
+                  <modelPackage>com.sphereon.pex.model</modelPackage>
+                  <supportingFilesToGenerate>
+                    ApiUtil.java
+                  </supportingFilesToGenerate>
+                  <configOptions>
+                    <delegatePattern>true</delegatePattern>
+                  </configOptions>
+                    <typeMappings>
+                      <typeMapping>OneOfnumberstring=Object</typeMapping>
+                  </typeMappings>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.sphereon.public</groupId>
@@ -11,8 +11,14 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <swagger.version>2.1.12</swagger.version>
+    <jackson.version>2.13.1</jackson.version>
+    <springfox.version>3.0.0</springfox.version>
+    <springdoc.version>1.6.5</springdoc.version>
+    <springboot.version>2.6.3</springboot.version>
+    <jackson-databind-nullable>0.2.1</jackson-databind-nullable>
+    <javax.version>2.0.1.Final</javax.version>
     <openapi-generator-version>5.3.1</openapi-generator-version>
     <swagger-codegen-verbose>false</swagger-codegen-verbose>
     <swagger-parser.version>2.0.26</swagger-parser.version>
@@ -36,6 +42,81 @@
     <developerConnection>scm:git:git@github.com:Sphereon-Opensource/pex-openapi.git</developerConnection>
     <url>https://github.com/Sphereon-Opensource/pex-openapi</url>
   </scm>
+
+  <dependencies>
+    <!--    5.4.0 has a bug with processing $ref inn yaml files, don't upgrade to that-->
+    <dependency>
+      <groupId>org.openapitools</groupId>
+      <artifactId>openapi-generator-maven-plugin</artifactId>
+      <version>${openapi-generator-version}</version>
+      <type>maven-plugin</type>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>${swagger.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-base</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${springboot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger2</artifactId>
+      <version>${springfox.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-ui</artifactId>
+      <version>${springdoc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-common</artifactId>
+      <version>${springdoc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>${javax.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openapitools</groupId>
+      <artifactId>jackson-databind-nullable</artifactId>
+      <version>${jackson-databind-nullable}</version>
+    </dependency>
+  </dependencies>
 
   <profiles>
     <profile>
@@ -88,7 +169,7 @@
                 </goals>
                 <phase>generate-sources</phase>
                 <configuration>
-                  <inputSpec>swagger/pex-openapi-1.1.0.yaml</inputSpec>
+                  <inputSpec>${open-api-address}</inputSpec>
 
                   <generatorName>typescript-angular</generatorName>
 
@@ -156,6 +237,11 @@
                 <artifactId>swagger-parser</artifactId>
                 <version>${swagger-parser.version}</version>
               </dependency>
+              <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+              </dependency>
             </dependencies>
             <executions>
               <execution>
@@ -196,13 +282,13 @@
       </build>
     </profile>
     <profile>
-      <id>models-java</id>
+      <id>java</id>
       <build>
         <plugins>
           <plugin>
             <groupId>org.openapitools</groupId>
             <artifactId>openapi-generator-maven-plugin</artifactId>
-            <version>5.4.0</version>
+            <version>${openapi-generator-version}</version>
             <executions>
               <execution>
                 <goals>
@@ -210,46 +296,33 @@
                 </goals>
                 <configuration>
                   <inputSpec>${open-api-address}</inputSpec>
-                  <generatorName>java</generatorName>
+                  <generatorName>spring</generatorName>
                   <apiPackage>com.sphereon.pex.api</apiPackage>
                   <modelPackage>com.sphereon.pex.model</modelPackage>
-                  <supportingFilesToGenerate>
-                    ApiUtil.java
-                  </supportingFilesToGenerate>
+                  <supportingFilesToGenerate>ApiUtil.java</supportingFilesToGenerate>
+                  <typeMappings>
+                    OneOfNumberString=Object
+                  </typeMappings>
                   <configOptions>
                     <delegatePattern>true</delegatePattern>
+                    <interfaceOnly>true</interfaceOnly>
                   </configOptions>
-                    <typeMappings>
-                      <typeMapping>OneOfnumberstring=Object</typeMapping>
-                  </typeMappings>
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.9.0</version>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+              <proc>none</proc>
+            </configuration>
           </plugin>
         </plugins>
       </build>
     </profile>
   </profiles>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>maven-central</id>
-      <name>Maven Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
-    </pluginRepository>
-  </pluginRepositories>
 </project>

--- a/swagger/pe/pd_filter_v1.yaml
+++ b/swagger/pe/pd_filter_v1.yaml
@@ -4,26 +4,18 @@ filter_v1:
   description: This is the filter that can be applied on the field's value to know if the available credential with a specifici field is acceptable or not.
   properties:
     "const":
-      oneOf:
-        - type: number
-        - type: string
+      $ref: './polymorphic_entity.yaml#/one_of_number_string'
       description: A fixed value that is acceptable in this variable
     "enum":
       type: array
       description: Fixed listed values which are acceptable in this variable.
       items:
-        oneOf:
-          - type: number
-          - type: string
+        $ref: './polymorphic_entity.yaml#/one_of_number_string'
     exclusiveMinimum:
-      oneOf:
-        - type: number
-        - type: string
+      $ref: './polymorphic_entity.yaml#/one_of_number_string'
       description: acceptable minimum value (e.g. 0) that is acceptable for the number exclusive of the number (i.e. 0 in this case)
     exclusiveMaximum:
-      oneOf:
-        - type: number
-        - type: string
+      $ref: './polymorphic_entity.yaml#/one_of_number_string'
       description: acceptable maximum value (e.g. 100) that is acceptable for the number exclusive of the number (i.e. 100 in this case)
     format:
       type: string
@@ -35,14 +27,10 @@ filter_v1:
       type: integer
       description: acceptable maximum length (e.g. of string) that is acceptable
     minimum:
-      oneOf:
-        - type: number
-        - type: string
+      $ref: './polymorphic_entity.yaml#/one_of_number_string'
       description: acceptable minimum value (e.g. 0) that is acceptable for the number including this number (i.e. 0 in this case)
     maximum:
-      oneOf:
-        - type: number
-        - type: string
+      $ref: './polymorphic_entity.yaml#/one_of_number_string'
       description: acceptable maximum value (e.g. 100) that is acceptable for the number including this number (i.e. 100 in this case)
     not:
       type: object

--- a/swagger/pe/pd_filter_v2.yaml
+++ b/swagger/pe/pd_filter_v2.yaml
@@ -4,26 +4,18 @@ filter_v2:
   description: This is the filter that can be applied on the field's value to know if the available credential with a specifici field is acceptable or not.
   properties:
     "const":
-      oneOf:
-        - type: number
-        - type: string
+      $ref: './polymorphic_entity.yaml#/one_of_number_string'
       description: A fixed value that is acceptable in this variable
     "enum":
       type: array
       description: Fixed listed values which are acceptable in this variable.
       items:
-        oneOf:
-          - type: number
-          - type: string
+        $ref: './polymorphic_entity.yaml#/one_of_number_string'
     exclusiveMinimum:
-      oneOf:
-        - type: number
-        - type: string
+      $ref: './polymorphic_entity.yaml#/one_of_number_string'
       description: acceptable minimum value (e.g. 0) that is acceptable for the number exclusive of the number (i.e. 0 in this case)
     exclusiveMaximum:
-      oneOf:
-        - type: number
-        - type: string
+      $ref: './polymorphic_entity.yaml#/one_of_number_string'
       description: acceptable maximum value (e.g. 100) that is acceptable for the number exclusive of the number (i.e. 100 in this case)
     format:
       type: string
@@ -47,14 +39,10 @@ filter_v2:
       type: integer
       description: acceptable maximum length (e.g. of string) that is acceptable
     minimum:
-      oneOf:
-        - type: number
-        - type: string
+      $ref: './polymorphic_entity.yaml#/one_of_number_string'
       description: acceptable minimum value (e.g. 0) that is acceptable for the number including this number (i.e. 0 in this case)
     maximum:
-      oneOf:
-        - type: number
-        - type: string
+      $ref: './polymorphic_entity.yaml#/one_of_number_string'
       description: acceptable maximum value (e.g. 100) that is acceptable for the number including this number (i.e. 100 in this case)
     not:
       type: object

--- a/swagger/pe/polymorphic_entity.yaml
+++ b/swagger/pe/polymorphic_entity.yaml
@@ -1,0 +1,6 @@
+one_of_number_string:
+  title: One of number or string
+  oneOf:
+    - type: number
+    - type: string
+  additionalProperties: false


### PR DESCRIPTION
added java generator to pex-openapi project. 
Since java generator for `openapi-generator-maven-plugin` doesn't support `oneOf` added a small tweak to generator configs to put `object` when encountering oneof