### PR TITLE
add `name` property to FieldV2

### DIFF
--- a/swagger/pe/pd_field_v2.yaml
+++ b/swagger/pe/pd_field_v2.yaml
@@ -19,4 +19,7 @@ field_v2:
       $ref: './pd_filter_v2.yaml#/filter_v2'
     predicate:
       $ref: './optionality.yaml#/optionality'
+    name:
+      type: string
+      description: human-friendly name that describes what the target field represents
   additionalProperties: false


### PR DESCRIPTION
This PR adds the `name` property to `FieldV2`. 

Reference from the [PEX V2 spec](https://identity.foundation/presentation-exchange/#input-descriptor-object)

<img width="825" alt="image" src="https://github.com/Sphereon-Opensource/pex-openapi/assets/4887440/aea7a712-3442-4924-8486-7b5dc63ac3ae">

also, just wanted to say thanks for all the hard work y'all have put into building and open sourcing the PEX libs! they've been really easy to use