### PR TITLE
feat: add support for vc+sd-jwt format

### DIFF
--- a/swagger/pe/pd_format.yaml
+++ b/swagger/pe/pd_format.yaml
@@ -19,3 +19,5 @@ format:
       $ref: './ldp_object.yaml#/ldp_object'
     ldp_vp:
       $ref: './ldp_object.yaml#/ldp_object'
+    vc+sd-jwt:
+      $ref: './sd_jwt_object.yaml#/sd_jwt_object'

--- a/swagger/pe/sd_jwt_object.yaml
+++ b/swagger/pe/sd_jwt_object.yaml
@@ -1,5 +1,17 @@
 sd_jwt_object:
   type: object
   description: Indicate support for SD-JWT VCs
-  properties: {}
+  properties:
+    sd-jwt_alg_values:
+      type: array
+      description: A JSON array containing identifiers of cryptographic algorithms the verifier supports for protection of a SD-JWT. If present, the alg JOSE header (as defined in [RFC7515]) of the presented SD-JWT MUST match one of the array values.
+      minItems: 1
+      items:
+        type: string
+    kb-jwt_alg_values:
+      type: array
+      description: A JSON array containing identifiers of cryptographic algorithms the verifier supports for protection of a KB-JWT. If present, the alg JOSE header (as defined in [RFC7515]) of the presented KB-JWT MUST match one of the array values.
+      minItems: 1
+      items:
+        type: string
   additionalProperties: false

--- a/swagger/pe/sd_jwt_object.yaml
+++ b/swagger/pe/sd_jwt_object.yaml
@@ -1,0 +1,5 @@
+sd_jwt_object:
+  type: object
+  description: Indicate support for SD-JWT VCs
+  properties: {}
+  additionalProperties: false


### PR DESCRIPTION
This adds support for the `vc+sd-jwt` format as described in HAIP. It's a bit weird, as the spec describes that the object must be empty: https://vcstuff.github.io/oid4vc-haip-sd-jwt-vc/draft-oid4vc-haip-sd-jwt-vc.html#name-presentation-definition

The actual alg values supported etc.. are defined in the client metadata, and not in the PD. This works ok when using this format with HAIP, but if you use e.g. DIDComm with PEX it would be nice to also have these values here. I think once the formats will be registered in the DIF registry, it may get some properties defined for the format: https://github.com/vcstuff/oid4vc-haip-sd-jwt-vc/issues/63

@nklomp do you agree with it being an empty object for now, or should we also allow the client metadata values (`sd-jwt_alg_values` and `kb-jwt_alg_values`) in the PD?