### PR TITLE
fix: type optional

### DIFF
--- a/openapi/pex-openapi.yaml
+++ b/openapi/pex-openapi.yaml
@@ -478,22 +478,9 @@ components:
         type:
           type: string
           description: Object type of the acceptable field.
-      required:
-        - type
       additionalProperties: false
 
     filter_v2:
-      allOf:
-        - $ref: "#/components/schemas/filter_v2_base"
-        - type: object
-          properties:
-            type:
-              type: string
-              description: Object type of the acceptable field.
-          required:
-            - type
-
-    filter_v2_base:
       title: Filter V2
       type: object
       description: This is the filter that can be applied on the field's value to know if the available credential with a specifici field is acceptable or not.
@@ -545,7 +532,7 @@ components:
           type: string
           description: Object type of the acceptable field.
         contains:
-          $ref: "#/components/schemas/filter_v2_base"
+          $ref: "#/components/schemas/filter_v2"
         items:
           anyOf:
             - $ref: "#/components/schemas/filter_v2"


### PR DESCRIPTION
Type is optional, and this was causing issues when validating a PD that didn't have `type`